### PR TITLE
Fixes Material Dialog shifting entire site on smaller screens

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -460,3 +460,7 @@ main {
 .slider {
   width: 100%;
 }
+
+.cdk-global-scrollblock {
+  top: auto !important;
+}


### PR DESCRIPTION
overrides material cdk-global-scrollblock that was shifting entire site on launched modal on smaller screens
closes #204